### PR TITLE
Update how we run the datasette browser

### DIFF
--- a/ansible/templates/run_dataset_browser.sh.j2
+++ b/ansible/templates/run_dataset_browser.sh.j2
@@ -1,4 +1,10 @@
 # supervisor can only control processes it started itself.
+
+ # fetching the most recent version of our dataset like this, as a separate step
+# use make to make sure we have a clean workspace, and all the dependencies sorted
+pipenv run make daily_snapshot.db
+
 # So we need to use exec to replace the parent shell script process
-# that starts pipenv
-exec pipenv run make serve
+# that starts pipenv. Otherwiser supervisor can not stop running processes,
+# as it only has the parent process id, not the one created by calling make
+exec pipenv run datasette ./daily_snapshot.db --template-dir=templates --static static:static


### PR DESCRIPTION
This changes how we run datasette on the main server, so supervisor can control it more easily.

This should give us cleaner deploys, as we'll be stopping and starting processes properly with the new code