### PR TITLE
Use 1.1 snapshot for Real time cloud data

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,10 +35,10 @@ all_dataset_dbs: daily_snapshot real_time_cloud_csvs real_time_cloud_db
 
 # fetch  the latest real time cloud dataset snapshots from object storage
 real_time_cloud_csvs:
-	wget https://github.com/Green-Software-Foundation/real-time-cloud/archive/refs/tags/v1.0.tar.gz -O /tmp/real-time-cloud.tar.gz
-	mkdir -p /tmp/real-time-cloud
-	tar -xzvf /tmp/real-time-cloud.tar.gz --strip-components 1 -C /tmp/real-time-cloud
-	mv /tmp/real-time-cloud/Cloud_Region_Metadata.csv cloud_region_metadata.csv
+	# Fetching using the latest csv snapshot from the 'dev' branch of the real time cloud dataset repo.	
+	# This gives us the latest data, because there is still a noticeable delay between data being updated and
+	# the GSF steering council ratifying a given release each time.
+	wget -O cloud_region_metadata.csv https://raw.githubusercontent.com/Green-Software-Foundation/real-time-cloud/refs/heads/Dev/Cloud_Region_Metadata.csv
 
 # create a sqlite databse for the real time cloud dataset and importy the csvs
 real_time_cloud_db:

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
         <hr />
         <h3>Real time cloud dataset</h3>
         <p>
-            Since 2023, The Green Web Foundation has been a member of the <a href="https://github.com/Green-Software-Foundation/real-time-cloud/">Green Software Foundation Real Time Cloud working group</a>, a project that has set out to define consistent, standard ways to report the carbon intensity of the computing hours sold by large cloud providers.
+            Since 2023, the Green Web Foundation has been a member of the <a href="https://github.com/Green-Software-Foundation/real-time-cloud/">Green Software Foundation Real Time Cloud working group</a>, a project that has set out to define consistent, standard ways to report the carbon intensity of the computing hours sold by large cloud providers.
         </p>
         <p>
             We have republished the key dataset created by the working group,
@@ -35,7 +35,7 @@
             See <a href="https://github.com/Green-Software-Foundation/real-time-cloud/blob/main/Cloud_Region_Metadata_specification.md">this link to documentation on the main project website</a> to understand what each column in the dataset means, and how it was created.
         </p>
         <p>
-            <a href="/cloud_regions/cloud_regions_metadata/">See the latest (v1.0) snapshot of the real time cloud metadata dataset</a>
+            <a href="/cloud_regions/cloud_regions_metadata/">See the latest (v1.1) snapshot of the real time cloud metadata dataset</a>
         </p>
         <strong>Licensing</strong>:
         <div class="gsf-license">


### PR DESCRIPTION
This PR makes the data in the 1.1 release of  the Real Time Cloud Cloud Metadata available on datasets.greenweb.org.

This makes 2024 data available from the big cloud providers

---

This pull request updates how the real-time cloud dataset is fetched and updates related documentation to reflect these changes. The most significant update is that the dataset is now pulled directly from the latest CSV snapshot on the 'Dev' branch, ensuring fresher data. Additionally, minor improvements were made to the user-facing documentation and links.

**Dataset Fetching Process:**
* Changed the `real_time_cloud_csvs` recipe in the `justfile` to download the latest `Cloud_Region_Metadata.csv` directly from the 'Dev' branch of the Green Software Foundation's real-time cloud repository, rather than using the latest tagged release.

**Documentation and User Interface:**
* Updated the description in `templates/index.html` to clarify the Green Web Foundation's involvement in the working group, improving the phrasing for clarity and consistency.
* Updated the link text in `templates/index.html` to indicate that the latest dataset snapshot is now version 1.1 instead of 1.0, reflecting the change to a newer dataset source.